### PR TITLE
Don't force using the inferred parser

### DIFF
--- a/stylelint-prettier.js
+++ b/stylelint-prettier.js
@@ -50,7 +50,6 @@ module.exports = stylelint.createPlugin(
 
       const prettierOptions = Object.assign({}, prettierRcOptions, options, {
         filepath,
-        parser: prettierFileInfo.inferredParser,
       });
       const prettierSource = prettier.format(source, prettierOptions);
 

--- a/test/prettierrc/default/.prettierrc
+++ b/test/prettierrc/default/.prettierrc
@@ -1,5 +1,11 @@
 {
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.wxss",
+      "options": { "parser": "css" }
+    }
+  ]
 }

--- a/test/stylelint-prettier.test.js
+++ b/test/stylelint-prettier.test.js
@@ -127,6 +127,29 @@ testRule(rule, {
   ],
 });
 
+// Use the parser specified in overrides in .prettierrc
+testRule(rule, {
+  ruleName: rule.ruleName,
+  config: true,
+  codeFilename: filename('default', 'dummy.wxss'),
+  accept: [
+    {
+      description: 'Prettier Valid - Default .prettierrc',
+      code: '.x {\n  color: red;\n}\n',
+    },
+  ],
+  reject: [
+    {
+      description: 'Prettier Insert - Default .prettierrc',
+      code: '.x {\ncolor: red;\n}\n',
+      fixed: '.x {\n  color: red;\n}\n',
+      message: 'Insert "··" (prettier/prettier)',
+      line: 2,
+      column: 1,
+    },
+  ],
+});
+
 // Ignoring files in .prettierignore
 testRule(rule, {
   ruleName: rule.ruleName,


### PR DESCRIPTION
The inferred parser does not take into account any overrides specified
in .prettierrc.

By not specifying a parser in the options, prettier shall still infer
the parser internally, at a point where overrides specified in
.prettierrc are resolved.

This means that users can specify parsers for custom file extensions
rather than be limited to the filename->parser mapping that prettier has
built-in.

Fixes #1